### PR TITLE
Changed sdcclib to sdar p

### DIFF
--- a/MakefileSrc.mk
+++ b/MakefileSrc.mk
@@ -1,7 +1,7 @@
 # Programs to use for creating dependencies, compiling source files, and creating the library file, respectively
 DEP = sdcc
 CC  = sdcc
-LIB = sdcclib
+LIB = sdar r
 
 # Flags for above programs when calling them from the command line
 DFLAGS = -MM $(INCDIRS) $<

--- a/MakefileTarget.mk
+++ b/MakefileTarget.mk
@@ -75,7 +75,7 @@ all:
 	$(ECHO) "Building target '$(TARGETNAME)' for library collection '$(LIBNAME)'"
 	@$(MAKE) $(SUBSRCDIRS)
 	-rm $(TARGETLIB)
-	sdcclib a $(TARGETLIB) obj/*/*.rel
+	sdar r $(TARGETLIB) obj/*/*.rel
 	$(ECHO)
 	$(ECHO) "Finished building target '$(TARGETNAME)' for library collection '$(LIBNAME)'"
 


### PR DESCRIPTION
Replaced `sdcclib` with `sdar p`. Tested on several projects.
For issue #7 